### PR TITLE
Fix COMPlus variables needed for asm diffing

### DIFF
--- a/mcgdiff.cs
+++ b/mcgdiff.cs
@@ -427,9 +427,7 @@ namespace ManagedCodeGen
                     generateCmd.EnvironmentVariable("COMPlus_NgenDisasm", "*");
                     generateCmd.EnvironmentVariable("COMPlus_NgenUnwindDump", "*");
                     generateCmd.EnvironmentVariable("COMPlus_NgenEHDump", "*");
-                    generateCmd.EnvironmentVariable("COMPlus_NgenOrder", "1");
                     generateCmd.EnvironmentVariable("COMPlus_JitDiffableDasm", "1");
-                    generateCmd.EnvironmentVariable("COMPlus_ZapSet", "dif");
                     
                     if (doGCDump) {
                         generateCmd.EnvironmentVariable("COMPlus_NgenGCDump", "*");


### PR DESCRIPTION
@russellhadley 

We don't want NgenOrder. And ZapSet isn't useful for crossgen (as far as I know).
