### PR TITLE
Update NetCoreApp to rc2-3002471

### DIFF
--- a/src/analyze/project.json
+++ b/src/analyze/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.0.0-rc2-3002353",
+    "Microsoft.NETCore.App": "1.0.0-rc2-3002471",
     "System.Runtime.Serialization.Primitives": "4.1.1-rc2-24018",
     "Microsoft.DotNet.Cli.Utils": "1.0.0-dev-*",
     "System.CommandLine": "0.1.0-*",

--- a/src/corediff/project.json
+++ b/src/corediff/project.json
@@ -5,7 +5,7 @@
   },
   
   "dependencies": {
-    "Microsoft.NETCore.App": "1.0.0-rc2-23931",
+    "Microsoft.NETCore.App": "1.0.0-rc2-3002471 ",
     "Microsoft.DotNet.Cli.Utils": "1.0.0-dev-*",
     "System.CommandLine": "0.1.0-*"
   },

--- a/src/mcgdiff/project.json
+++ b/src/mcgdiff/project.json
@@ -5,7 +5,7 @@
     },
 
     "dependencies": {
-        "Microsoft.NETCore.App": "1.0.0-rc2-23931",
+        "Microsoft.NETCore.App": "1.0.0-rc2-3002471",
         "Microsoft.DotNet.Cli.Utils": "1.0.0-dev-*",
         "System.CommandLine": "0.1.0-*"
     },


### PR DESCRIPTION
Update to new platform assemblies.  Resolves .deps issue with new dotnet tools.
