### PR TITLE
Add an enumeration to force files to close

### DIFF
--- a/src/analyze/analyze.cs
+++ b/src/analyze/analyze.cs
@@ -205,7 +205,7 @@ namespace ManagedCodeGen
                                  functionOffsets = x.Select(z => z)
                                                     .Where(z => z.functionOffset != 0)
                                                     .Select(z => z.functionOffset).ToList()
-                             });
+                             }).ToList();
         }
 
         // Compare base and diff file lists and produce a sorted list of method


### PR DESCRIPTION
Cut up the linq querys with an enumeration to force data extration and file closure.  This allows code to run with out triggering the "to many file handles open" error.
