### PR TITLE
Replace exit with return in script

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -2,12 +2,12 @@
 
 if ! dotnet --info; then 
     echo "Can't find dotnet! Please add to PATH."
-    exit 1
+    return 1
 fi
 
 if ! git --version; then 
     echo "Can't find git! Please add to PATH."
-    exit 1
+    return 1
 fi
 
 root=$(pwd)


### PR DESCRIPTION
When script is sourced the exits cause the session to end.  Switching to return gives us the semantics we want.
