### PR TITLE
Run standard C# OSS code formater

### DIFF
--- a/src/analyze/analyze.cs
+++ b/src/analyze/analyze.cs
@@ -12,7 +12,7 @@ using Newtonsoft.Json;
 namespace ManagedCodeGen
 {
     public class analyze
-    {   
+    {
         public class Config
         {
             private ArgumentSyntax syntaxResult;
@@ -24,40 +24,43 @@ namespace ManagedCodeGen
             private int count = 5;
             private string json;
             private string csv;
-            
-            public Config(string[] args) {
 
+            public Config(string[] args)
+            {
                 syntaxResult = ArgumentSyntax.Parse(args, syntax =>
                 {
                     syntax.DefineOption("b|base", ref basePath, "Base file or directory.");
                     syntax.DefineOption("d|diff", ref diffPath, "Diff file or directory.");
                     syntax.DefineOption("r|recursive", ref recursive, "Search directories recursively.");
-                    syntax.DefineOption("c|count", ref count, 
+                    syntax.DefineOption("c|count", ref count,
                         "Count of files and methods (at most) to output in the summary."
                       + " (count) improvements and (count) regressions of each will be included."
                       + " (default 5)");
-                    syntax.DefineOption("w|warn", ref warn, 
+                    syntax.DefineOption("w|warn", ref warn,
                         "Generate warning output for files/methods that only "
                       + "exists in one dataset or the other (only in base or only in diff).");
-                    syntax.DefineOption("json", ref json, 
+                    syntax.DefineOption("json", ref json,
                         "Dump analysis data to specified file in JSON format.");
                     syntax.DefineOption("csv", ref csv, "Dump analysis data to specified file in CSV format.");
                 });
-                
+
                 // Run validation code on parsed input to ensure we have a sensible scenario.
                 validate();
             }
-            
-            void validate() {
-                if (basePath == null) {
+
+            private void validate()
+            {
+                if (basePath == null)
+                {
                     syntaxResult.ReportError("Base path (--base) is required.");
                 }
-                
-                if (diffPath == null) {
+
+                if (diffPath == null)
+                {
                     syntaxResult.ReportError("Diff path (--diff) is required.");
                 }
             }
-            
+
             public string BasePath { get { return basePath; } }
             public string DiffPath { get { return diffPath; } }
             public bool Recursive { get { return recursive; } }
@@ -69,16 +72,18 @@ namespace ManagedCodeGen
             public bool DoGenerateJson { get { return json != null; } }
             public bool DoGenerateCSV { get { return csv != null; } }
         }
-        
-        public class FileInfo {
+
+        public class FileInfo
+        {
             public string path;
             public IEnumerable<MethodInfo> methodList;
         }
-        
+
         // Custom comparer for the FileInfo class
-        class FileInfoComparer : IEqualityComparer<FileInfo>
+        private class FileInfoComparer : IEqualityComparer<FileInfo>
         {
-            public bool Equals(FileInfo x, FileInfo y) {
+            public bool Equals(FileInfo x, FileInfo y)
+            {
                 if (Object.ReferenceEquals(x, y)) return true;
                 if (Object.ReferenceEquals(x, null) || Object.ReferenceEquals(y, null))
                     return false;
@@ -88,30 +93,34 @@ namespace ManagedCodeGen
             // If Equals() returns true for a pair of objects 
             // then GetHashCode() must return the same value for these objects.
 
-            public int GetHashCode(FileInfo fi) {
+            public int GetHashCode(FileInfo fi)
+            {
                 if (Object.ReferenceEquals(fi, null)) return 0;
                 return fi.path == null ? 0 : fi.path.GetHashCode();
             }
         }
 
-        public class MethodInfo {
+        public class MethodInfo
+        {
             public string name;
             public int totalBytes;
             public int prologBytes;
             public int functionCount;
             public IEnumerable<int> functionOffsets;
-            public override string ToString() {
-                return String.Format(@"name {0}, total bytes {1}, prolog bytes {2}, " 
+            public override string ToString()
+            {
+                return String.Format(@"name {0}, total bytes {1}, prolog bytes {2}, "
                     + "function count {3}, offsets {4}",
-                    name, totalBytes, prologBytes, functionCount, 
+                    name, totalBytes, prologBytes, functionCount,
                     String.Join(", ", functionOffsets.ToArray()));
             }
         }
-        
+
         // Custom comparer for the MethodInfo class
-        class MethodInfoComparer : IEqualityComparer<MethodInfo>
+        private class MethodInfoComparer : IEqualityComparer<MethodInfo>
         {
-            public bool Equals(MethodInfo x, MethodInfo y) {
+            public bool Equals(MethodInfo x, MethodInfo y)
+            {
                 if (Object.ReferenceEquals(x, y)) return true;
                 if (Object.ReferenceEquals(x, null) || Object.ReferenceEquals(y, null))
                     return false;
@@ -121,21 +130,24 @@ namespace ManagedCodeGen
             // If Equals() returns true for a pair of objects 
             // then GetHashCode() must return the same value for these objects.
 
-            public int GetHashCode(MethodInfo mi) {
+            public int GetHashCode(MethodInfo mi)
+            {
                 if (Object.ReferenceEquals(mi, null)) return 0;
                 return mi.name == null ? 0 : mi.name.GetHashCode();
             }
         }
-        
-        public class FileDelta {
+
+        public class FileDelta
+        {
             public string path;
             public int deltaBytes;
             public IEnumerable<MethodInfo> methodsOnlyInBase;
             public IEnumerable<MethodInfo> methodsOnlyInDiff;
             public IEnumerable<MethodDelta> methodDeltaList;
         }
-        
-        public class MethodDelta {
+
+        public class MethodDelta
+        {
             public string name;
             public int baseBytes;
             public int diffBytes;
@@ -143,52 +155,59 @@ namespace ManagedCodeGen
             public IEnumerable<int> baseOffsets;
             public IEnumerable<int> diffOffsets;
         }
-        
-        public static IEnumerable<FileInfo> ExtractFileInfo(string path, bool recursive) {        
+
+        public static IEnumerable<FileInfo> ExtractFileInfo(string path, bool recursive)
+        {
             // if path is a directory, enumerate files and extract
             // otherwise just extract.
-            SearchOption searchOption = (recursive) ? 
+            SearchOption searchOption = (recursive) ?
                 SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
             FileAttributes attr = File.GetAttributes(path);
             string fullRootPath = Path.GetFullPath(path);
 
-            if ((attr & FileAttributes.Directory) == FileAttributes.Directory) {
+            if ((attr & FileAttributes.Directory) == FileAttributes.Directory)
+            {
                 return Directory.EnumerateFiles(fullRootPath, "*.dasm", searchOption)
-                         .Select(p => new FileInfo {
+                         .Select(p => new FileInfo
+                         {
                              path = p.Substring(fullRootPath.Length).TrimStart(Path.DirectorySeparatorChar),
                              methodList = ExtractMethodInfo(p)
                          });
             }
-            else {
+            else
+            {
                 // In the single file case just create a list with a single
                 // to satisfy the interface.
-                return new List<FileInfo> { new FileInfo { 
-                        path = Path.GetFileName(path), 
+                return new List<FileInfo> { new FileInfo {
+                        path = Path.GetFileName(path),
                         methodList = ExtractMethodInfo(path)
                     }
                 };
-            }   
+            }
         }
 
         // Extract lines of the passed in file and create a method info object
         // for each method descript line containing total bytes, prolog bytes, 
         // and offset in the file.
-        public static IEnumerable<MethodInfo> ExtractMethodInfo(string filePath) {
+        public static IEnumerable<MethodInfo> ExtractMethodInfo(string filePath)
+        {
             Regex namePattern = new Regex(@"for method (.*)$");
             Regex dataPattern = new Regex(@"code ([0-9]{1,}), prolog size ([0-9]{1,})");
             return File.ReadLines(filePath)
-                             .Select((x,i) => new {line = x, index = i})
-                             .Where(l => l.line.StartsWith(@"; Total bytes of code") 
+                             .Select((x, i) => new { line = x, index = i })
+                             .Where(l => l.line.StartsWith(@"; Total bytes of code")
                                         || l.line.StartsWith(@"; Assembly listing for method"))
-                             .Select((x) => {
+                             .Select((x) =>
+                             {
                                  var nameMatch = namePattern.Match(x.line);
                                  var dataMatch = dataPattern.Match(x.line);
-                                 return new { 
+                                 return new
+                                 {
                                      name = nameMatch.Groups[1].Value,
                                      // Use matched data or default to 0
-                                     totalBytes = dataMatch.Success ? 
+                                     totalBytes = dataMatch.Success ?
                                         Int32.Parse(dataMatch.Groups[1].Value) : 0,
-                                     prologBytes = dataMatch.Success ? 
+                                     prologBytes = dataMatch.Success ?
                                         Int32.Parse(dataMatch.Groups[2].Value) : 0,
                                      // Use function index only from non-data lines (the name line)
                                      functionOffset = dataMatch.Success ?
@@ -196,7 +215,8 @@ namespace ManagedCodeGen
                                  };
                              })
                              .GroupBy(x => x.name)
-                             .Select(x => new MethodInfo {
+                             .Select(x => new MethodInfo
+                             {
                                  name = x.Key,
                                  totalBytes = x.Sum(z => z.totalBytes),
                                  prologBytes = x.Sum(z => z.prologBytes),
@@ -211,12 +231,15 @@ namespace ManagedCodeGen
         // Compare base and diff file lists and produce a sorted list of method
         // deltas by file.  Delta is computed diffBytes - baseBytes so positive
         // numbers are regressions. (lower is better)       
-        public static IEnumerable<FileDelta> Comparator(IEnumerable<FileInfo> baseInfo, 
-            IEnumerable<FileInfo> diffInfo) {
-            MethodInfoComparer methodInfoComparer = new MethodInfoComparer();    
-            return baseInfo.Join(diffInfo, b => b.path, d => d.path, (b, d) => {
-                var deltaList = b.methodList.Join(d.methodList, 
-                        x => x.name, y => y.name, (x, y) => new MethodDelta {
+        public static IEnumerable<FileDelta> Comparator(IEnumerable<FileInfo> baseInfo,
+            IEnumerable<FileInfo> diffInfo)
+        {
+            MethodInfoComparer methodInfoComparer = new MethodInfoComparer();
+            return baseInfo.Join(diffInfo, b => b.path, d => d.path, (b, d) =>
+            {
+                var deltaList = b.methodList.Join(d.methodList,
+                        x => x.name, y => y.name, (x, y) => new MethodDelta
+                        {
                             name = x.name,
                             baseBytes = x.totalBytes,
                             diffBytes = y.totalBytes,
@@ -225,16 +248,17 @@ namespace ManagedCodeGen
                         })
                         .Where(r => r.deltaBytes != 0)
                         .OrderByDescending(r => r.deltaBytes);
-                return new FileDelta {
+                return new FileDelta
+                {
                     path = b.path,
                     deltaBytes = deltaList.Sum(x => x.deltaBytes),
                     methodsOnlyInBase = b.methodList.Except(d.methodList, methodInfoComparer),
-                    methodsOnlyInDiff = d.methodList.Except(b.methodList, methodInfoComparer), 
+                    methodsOnlyInDiff = d.methodList.Except(b.methodList, methodInfoComparer),
                     methodDeltaList = deltaList
                 };
             });
         }
-        
+
         // Summarize differences across all the files.
         // Output:
         //     Total bytes differences
@@ -242,171 +266,209 @@ namespace ManagedCodeGen
         //     Top 5 diffs by size across all files
         //
         //
-        public static int Summarize(IEnumerable<FileDelta> fileDeltaList, int requestedCount) {
+        public static int Summarize(IEnumerable<FileDelta> fileDeltaList, int requestedCount)
+        {
             var totalBytes = fileDeltaList.Sum(x => x.deltaBytes);
             Console.WriteLine("\nSummary:\n(Note: Lower is better)\n");
             Console.WriteLine("Total bytes of diff: {0}", totalBytes.ToString());
-            if (totalBytes != 0) {
-                Console.WriteLine("    diff is {0}", totalBytes < 0 ? "an improvement." : "a regression."); 
+            if (totalBytes != 0)
+            {
+                Console.WriteLine("    diff is {0}", totalBytes < 0 ? "an improvement." : "a regression.");
             }
-            else {
+            else
+            {
                 // Early out if there are not bytes of difference.
                 return totalBytes;
             }
- 
+
             var sortedFileDelta = fileDeltaList
                                       .Where(x => x.deltaBytes != 0)
                                       .OrderByDescending(d => d.deltaBytes).ToList();
             int sortedFileCount = sortedFileDelta.Count();
-            int fileCount = (sortedFileCount < requestedCount) 
-                ? sortedFileCount : requestedCount; 
-            if (sortedFileDelta[0].deltaBytes > 0) {
-                Console.WriteLine("\nTop file regressions by size (bytes):");                          
+            int fileCount = (sortedFileCount < requestedCount)
+                ? sortedFileCount : requestedCount;
+            if (sortedFileDelta[0].deltaBytes > 0)
+            {
+                Console.WriteLine("\nTop file regressions by size (bytes):");
                 foreach (var fileDelta in sortedFileDelta.GetRange(0, fileCount)
-                                                         .Where(x => x.deltaBytes > 0)) {
+                                                         .Where(x => x.deltaBytes > 0))
+                {
                     Console.WriteLine("    {1} : {0}", fileDelta.path, fileDelta.deltaBytes);
                 }
             }
 
-            if (sortedFileDelta.Last().deltaBytes < 0) {
+            if (sortedFileDelta.Last().deltaBytes < 0)
+            {
                 // index of the element count from the end.
                 int fileDeltaIndex = (sortedFileDelta.Count() - fileCount);
                 Console.WriteLine("\nTop file improvements by size (bytes):");
 
                 foreach (var fileDelta in sortedFileDelta.GetRange(fileDeltaIndex, fileCount)
                                                         .Where(x => x.deltaBytes < 0)
-                                                        .OrderBy(x => x.deltaBytes)) {
+                                                        .OrderBy(x => x.deltaBytes))
+                {
                     Console.WriteLine("    {1} : {0}", fileDelta.path, fileDelta.deltaBytes);
                 }
             }
-            
+
             Console.WriteLine("\n{0} total files with size differences.", sortedFileCount);
-          
+
             var sortedMethodDelta = fileDeltaList
-                                        .SelectMany(fd => fd.methodDeltaList, (fd, md) => new {
+                                        .SelectMany(fd => fd.methodDeltaList, (fd, md) => new
+                                        {
                                             path = fd.path,
                                             name = md.name,
                                             deltaBytes = md.deltaBytes
                                         }).OrderByDescending(x => x.deltaBytes).ToList();
             int sortedMethodCount = sortedMethodDelta.Count();
-            int methodCount = (sortedMethodCount < requestedCount) 
+            int methodCount = (sortedMethodCount < requestedCount)
                 ? sortedMethodCount : requestedCount;
-            if (sortedMethodDelta[0].deltaBytes > 0) {
+            if (sortedMethodDelta[0].deltaBytes > 0)
+            {
                 Console.WriteLine("\nTop method regessions by size (bytes):");
-                
+
                 foreach (var method in sortedMethodDelta.GetRange(0, methodCount)
-                                                        .Where(x => x.deltaBytes > 0)) {
+                                                        .Where(x => x.deltaBytes > 0))
+                {
                     Console.WriteLine("    {2} : {0} - {1}", method.path, method.name, method.deltaBytes);
                 }
             }
 
-            if (sortedMethodDelta.Last().deltaBytes < 0) {
-                 // index of the element count from the end.
+            if (sortedMethodDelta.Last().deltaBytes < 0)
+            {
+                // index of the element count from the end.
                 int methodDeltaIndex = (sortedMethodCount - methodCount);
                 Console.WriteLine("\nTop method improvements by size (bytes):");
 
                 foreach (var method in sortedMethodDelta.GetRange(methodDeltaIndex, methodCount)
                                                         .Where(x => x.deltaBytes < 0)
-                                                        .OrderBy(x => x.deltaBytes)) {
+                                                        .OrderBy(x => x.deltaBytes))
+                {
                     Console.WriteLine("    {2} : {0} - {1}", method.path, method.name, method.deltaBytes);
                 }
             }
-            
+
             Console.WriteLine("\n{0} total methods with size differences.", sortedMethodCount);
-            
+
             return Math.Abs(totalBytes);
         }
- 
-        public static void WarnFiles(IEnumerable<FileInfo> diffList, IEnumerable<FileInfo> baseList) {
+
+        public static void WarnFiles(IEnumerable<FileInfo> diffList, IEnumerable<FileInfo> baseList)
+        {
             FileInfoComparer fileInfoComparer = new FileInfoComparer();
             var onlyInBaseList = baseList.Except(diffList, fileInfoComparer);
             var onlyInDiffList = diffList.Except(baseList, fileInfoComparer);
-            
+
             //  Go through the files and flag anything not in both lists.
 
             var onlyInBaseCount = onlyInBaseList.Count();
-            if (onlyInBaseCount > 0) {
+            if (onlyInBaseCount > 0)
+            {
                 Console.WriteLine("Warning: {0} files in base but not in diff.", onlyInBaseCount);
                 Console.WriteLine("\nOnly in base files:");
-                foreach(var file in onlyInBaseList) {
+                foreach (var file in onlyInBaseList)
+                {
                     Console.WriteLine(file.path);
                 }
             }
-            
+
             var onlyInDiffCount = onlyInDiffList.Count();
-            if (onlyInDiffCount > 0) {
+            if (onlyInDiffCount > 0)
+            {
                 Console.WriteLine("Warning: {0} files in diff but not in base.", onlyInDiffCount);
                 Console.WriteLine("\nOnly in diff files:");
-                foreach(var file in onlyInDiffList) {
+                foreach (var file in onlyInDiffList)
+                {
                     Console.WriteLine(file.path);
                 }
-            } 
+            }
         }
-        
-        public static void WarnMethods(IEnumerable<FileDelta> compareList) {
-            foreach(var delta in compareList) {
+
+        public static void WarnMethods(IEnumerable<FileDelta> compareList)
+        {
+            foreach (var delta in compareList)
+            {
                 var onlyInBaseCount = delta.methodsOnlyInBase.Count();
                 var onlyInDiffCount = delta.methodsOnlyInDiff.Count();
-                
-                if ((onlyInBaseCount > 0) || (onlyInDiffCount > 0)) {
+
+                if ((onlyInBaseCount > 0) || (onlyInDiffCount > 0))
+                {
                     Console.WriteLine("Mismatched methods in {0}", delta.path);
-                    if(onlyInBaseCount > 0) {
+                    if (onlyInBaseCount > 0)
+                    {
                         Console.WriteLine("Base:");
-                        foreach (var method in delta.methodsOnlyInBase) {
+                        foreach (var method in delta.methodsOnlyInBase)
+                        {
                             Console.WriteLine("    {0}", method.name);
                         }
                     }
-                    if (onlyInDiffCount > 0) {
+                    if (onlyInDiffCount > 0)
+                    {
                         Console.WriteLine("Diff:");
-                        foreach (var method in delta.methodsOnlyInDiff) {
+                        foreach (var method in delta.methodsOnlyInDiff)
+                        {
                             Console.WriteLine("    {0}", method.name);
-                        }   
+                        }
                     }
                 }
             }
         }
-        
-        public static void GenerateJson(IEnumerable<FileDelta> compareList, string path) {
-            using (var outputStream = System.IO.File.Create(path)) {
-                using (var outputStreamWriter = new StreamWriter(outputStream)) {
-                    foreach(var file in compareList) {
-                        if (file.deltaBytes == 0) {
+
+        public static void GenerateJson(IEnumerable<FileDelta> compareList, string path)
+        {
+            using (var outputStream = System.IO.File.Create(path))
+            {
+                using (var outputStreamWriter = new StreamWriter(outputStream))
+                {
+                    foreach (var file in compareList)
+                    {
+                        if (file.deltaBytes == 0)
+                        {
                             // Early out if there are no diff bytes.
                             continue;
                         }
-                                                      
-                        try {
+
+                        try
+                        {
                             // Serialize file delta to output file.
                             outputStreamWriter.Write(JsonConvert.SerializeObject(file, Formatting.Indented));
                         }
-                        catch (Exception e) {
+                        catch (Exception e)
+                        {
                             Console.WriteLine("Exception serializing JSON: {0}", e.ToString());
                             break;
                         }
                     }
                 }
-            }  
+            }
         }
-        
-        public static void GenerateCSV(IEnumerable<FileDelta> compareList, string path) {
-            using (var outputStream = System.IO.File.Create(path)) {
-                using (var outputStreamWriter = new StreamWriter(outputStream)) {
+
+        public static void GenerateCSV(IEnumerable<FileDelta> compareList, string path)
+        {
+            using (var outputStream = System.IO.File.Create(path))
+            {
+                using (var outputStreamWriter = new StreamWriter(outputStream))
+                {
                     outputStreamWriter.WriteLine("File, Method, Diff bytes, Base bytes");
-                    foreach(var file in compareList) {
-                        if (file.deltaBytes == 0) {
+                    foreach (var file in compareList)
+                    {
+                        if (file.deltaBytes == 0)
+                        {
                             // Early out if there are no diff bytes.
                             continue;
                         }
-                        
-                        foreach (var method in file.methodDeltaList) {
+
+                        foreach (var method in file.methodDeltaList)
+                        {
                             outputStreamWriter.WriteLine("{0}, {1}, {2}, {3}", file.path, method.name, method.diffBytes, method.baseBytes);
                         }
                     }
                 }
-            }  
+            }
         }
-        
-        public static bool DiffInText(string diffPath, string basePath) {
+
+        public static bool DiffInText(string diffPath, string basePath)
+        {
             // run get diff command to see if we have textual diffs.
             // (use git diff since it's already a dependency and cross platform)
             List<string> commandArgs = new List<string>();
@@ -418,10 +480,11 @@ namespace ManagedCodeGen
             Command diffCmd = Command.Create(@"git", commandArgs);
             diffCmd.CaptureStdOut();
             diffCmd.CaptureStdErr();
-            
+
             CommandResult result = diffCmd.Execute();
-            
-            if (result.ExitCode != 0) {
+
+            if (result.ExitCode != 0)
+            {
                 // TODO - there's some issue with capturing stdout.  Just leave this commented out for now.
                 // Console.WriteLine("here {0}", result.StdOut);
                 // var lines = result.StdOut.Split(new [] {Environment.NewLine}, StringSplitOptions.None).ToList();
@@ -430,18 +493,19 @@ namespace ManagedCodeGen
             }
             return false;
         }
- 
+
         public static int Main(string[] args)
         {
             // Parse incoming arguments
             Config config = new Config(args);
-            
+
             // Early out if no textual diffs found.
-            if (!DiffInText(config.DiffPath, config.BasePath)) {
+            if (!DiffInText(config.DiffPath, config.BasePath))
+            {
                 Console.WriteLine("No diffs found.");
                 return 0;
             }
-            
+
             // Extract method info from base and diff directory or file.
             var baseList = ExtractFileInfo(config.BasePath, config.Recursive);
             var diffList = ExtractFileInfo(config.DiffPath, config.Recursive);
@@ -452,21 +516,24 @@ namespace ManagedCodeGen
             // has both sides.
 
             var compareList = Comparator(baseList, diffList);
-            
+
             // Generate warning lists if requested.
-            if (config.Warn) {
+            if (config.Warn)
+            {
                 WarnFiles(diffList, baseList);
                 WarnMethods(compareList);
             }
-            
-            if (config.DoGenerateCSV) {
+
+            if (config.DoGenerateCSV)
+            {
                 GenerateCSV(compareList, config.CSVFileName);
             }
-            
-            if (config.DoGenerateJson) {
+
+            if (config.DoGenerateJson)
+            {
                 GenerateJson(compareList, config.JsonFileName);
             }
-            
+
             return Summarize(compareList, config.Count);
         }
     }

--- a/src/corediff/corediff.cs
+++ b/src/corediff/corediff.cs
@@ -11,7 +11,7 @@ namespace ManagedCodeGen
     public class corediff
     {
         private static string asmTool = "mcgdiff";
-        
+
         public class Config
         {
             private ArgumentSyntax syntaxResult;
@@ -23,9 +23,9 @@ namespace ManagedCodeGen
             private string testPath = null;
             private bool mscorlibOnly = false;
             private bool frameworksOnly = false;
-            
-            public Config(string[] args) {
 
+            public Config(string[] args)
+            {
                 syntaxResult = ArgumentSyntax.Parse(args, syntax =>
                 {
                     syntax.DefineOption("b|base", ref baseExe, "The base compiler exe.");
@@ -37,31 +37,36 @@ namespace ManagedCodeGen
                     syntax.DefineOption("core_root", ref platformPath, "Path to test CORE_ROOT.");
                     syntax.DefineOption("test_root", ref testPath, "Path to test tree");
                 });
-                
+
                 // Run validation code on parsed input to ensure we have a sensible scenario.
-                
+
                 validate();
             }
-            
-            void validate() {
-                if (platformPath == null) {
+
+            private void validate()
+            {
+                if (platformPath == null)
+                {
                     syntaxResult.ReportError("Specifiy --core_root <path>");
                 }
-                
-                if ((mscorlibOnly == false) && 
-                    (frameworksOnly == false) && (testPath == null)) {
+
+                if ((mscorlibOnly == false) &&
+                    (frameworksOnly == false) && (testPath == null))
+                {
                     syntaxResult.ReportError("Specify --test_root <path>");
                 }
-                
-                if (outputPath == null) {
+
+                if (outputPath == null)
+                {
                     syntaxResult.ReportError("Specify --output <path>");
                 }
-                
-                if ((baseExe == null) && (diffExe == null)) {
+
+                if ((baseExe == null) && (diffExe == null))
+                {
                     syntaxResult.ReportError("--base <path> or --diff <path> or both must be specified.");
                 }
             }
-            
+
             public string CoreRoot { get { return platformPath; } }
             public string TestRoot { get { return testPath; } }
             public string PlatformPath { get { return platformPath; } }
@@ -78,31 +83,31 @@ namespace ManagedCodeGen
             public bool DoFrameworks { get { return !mscorlibOnly; } }
             public bool DoTestTree { get { return (!mscorlibOnly && !frameworksOnly); } }
         }
- 
-        private static string[] testDirectories = 
+
+        private static string[] testDirectories =
         {
             "Interop",
             "JIT"
         };
-        
-        private static string[] frameworkAssemblies = 
+
+        private static string[] frameworkAssemblies =
         {
-            "mscorlib.dll",			
-            "System.Runtime.dll",		
-            "System.Runtime.Extensions.dll",		
-            "System.Runtime.Handles.dll",		
-            "System.Runtime.InteropServices.dll",		
-            "System.Runtime.InteropServices.PInvoke.dll",		
+            "mscorlib.dll",
+            "System.Runtime.dll",
+            "System.Runtime.Extensions.dll",
+            "System.Runtime.Handles.dll",
+            "System.Runtime.InteropServices.dll",
+            "System.Runtime.InteropServices.PInvoke.dll",
             "System.Runtime.InteropServices.RuntimeInformation.dll",
-            "System.Runtime.Numerics.dll",			
-            "Microsoft.CodeAnalysis.dll",		
-            "Microsoft.CodeAnalysis.CSharp.dll",		
+            "System.Runtime.Numerics.dll",
+            "Microsoft.CodeAnalysis.dll",
+            "Microsoft.CodeAnalysis.CSharp.dll",
             "System.Collections.dll",
-            "System.Collections.Concurrent.dll",		
-            "System.Collections.Immutable.dll",		
-            "System.Collections.NonGeneric.dll",		
-            "System.Collections.Specialized.dll",		
-            "System.ComponentModel.dll",		
+            "System.Collections.Concurrent.dll",
+            "System.Collections.Immutable.dll",
+            "System.Collections.NonGeneric.dll",
+            "System.Collections.Specialized.dll",
+            "System.ComponentModel.dll",
             "System.Console.dll",
             "System.Dynamic.Runtime.dll",
             "System.IO.dll",
@@ -115,7 +120,7 @@ namespace ManagedCodeGen
             "System.Net.Primitives.dll",
             "System.Net.Requests.dll",
             "System.Net.Security.dll",
-            "System.Net.Sockets.dll",		
+            "System.Net.Sockets.dll",
             "System.Numerics.Vectors.dll",
             "System.Reflection.dll",
             "System.Reflection.DispatchProxy.dll",
@@ -126,114 +131,125 @@ namespace ManagedCodeGen
             "System.Reflection.Metadata.dll",
             "System.Reflection.Primitives.dll",
             "System.Reflection.TypeExtensions.dll",
-            "System.Text.Encoding.dll",		
-            "System.Text.Encoding.Extensions.dll",		
-            "System.Text.RegularExpressions.dll",		
-            "System.Xml.ReaderWriter.dll",		
-            "System.Xml.XDocument.dll",		
+            "System.Text.Encoding.dll",
+            "System.Text.Encoding.Extensions.dll",
+            "System.Text.RegularExpressions.dll",
+            "System.Xml.ReaderWriter.dll",
+            "System.Xml.XDocument.dll",
             "System.Xml.XmlDocument.dll"
         };
-        
+
         public static int Main(string[] args)
         {
             Config config = new Config(args);
             string diffString = "mscorlib.dll";
-            
-            if (config.DoFrameworks) {
+
+            if (config.DoFrameworks)
+            {
                 diffString += ", framework assemblies";
             }
-            
-            if (config.DoTestTree) {
+
+            if (config.DoTestTree)
+            {
                 diffString += ", " + config.TestRoot;
             }
-            
+
             Console.WriteLine("Beginning diff of {0}!", diffString);
-            
+
             // Add each framework assembly to commandArgs
-            
+
             // Create subjob that runs mcgdiff, which should be in path, with the 
             // relevent coreclr assemblies/paths.
-            
+
             string frameworkArgs = String.Join(" ", frameworkAssemblies);
             string testArgs = String.Join(" ", testDirectories);
-            
-            
+
+
             List<string> commandArgs = new List<string>();
-            
+
             // Set up CoreRoot
             commandArgs.Add("--platform");
             commandArgs.Add(config.CoreRoot);
-            
+
             commandArgs.Add("--output");
             commandArgs.Add(config.OutputPath);
-            
-            if (config.HasBaseExeutable) {
-                commandArgs.Add("--base");  
+
+            if (config.HasBaseExeutable)
+            {
+                commandArgs.Add("--base");
                 commandArgs.Add(config.BaseExecutable);
             }
-            
-            if (config.HasDiffExecutable) {
+
+            if (config.HasDiffExecutable)
+            {
                 commandArgs.Add("--diff");
                 commandArgs.Add(config.DiffExecutable);
             }
-            
-            if (config.HasTag) {
+
+            if (config.HasTag)
+            {
                 commandArgs.Add("--tag");
                 commandArgs.Add(config.Tag);
             }
 
-            if (config.MSCorelibOnly) {
+            if (config.MSCorelibOnly)
+            {
                 string coreRoot = config.CoreRoot;
                 string fullPathAssembly = Path.Combine(coreRoot, "mscorlib.dll");
                 commandArgs.Add(fullPathAssembly);
             }
-            else {
+            else
+            {
                 // Set up full framework paths
-                foreach (var assembly in frameworkAssemblies) {
+                foreach (var assembly in frameworkAssemblies)
+                {
                     string coreRoot = config.CoreRoot;
                     string fullPathAssembly = Path.Combine(coreRoot, assembly);
-                    
-                    if (!File.Exists(fullPathAssembly)) {
+
+                    if (!File.Exists(fullPathAssembly))
+                    {
                         Console.WriteLine("can't find {0}", fullPathAssembly);
                         continue;
                     }
-                    
+
                     commandArgs.Add(fullPathAssembly);
                 }
 
-                if (config.TestRoot != null) {
-                    foreach (var dir in testDirectories) {
+                if (config.TestRoot != null)
+                {
+                    foreach (var dir in testDirectories)
+                    {
                         string testRoot = config.TestRoot;
                         string fullPathDir = Path.Combine(testRoot, dir);
-                        
-                        if (!Directory.Exists(fullPathDir)) {
+
+                        if (!Directory.Exists(fullPathDir))
+                        {
                             Console.WriteLine("can't find {0}", fullPathDir);
                             continue;
                         }
-                        
+
                         commandArgs.Add(fullPathDir);
-                        // Set up resursive search
-                        commandArgs.Add("--recursive");
-                    } 
+                    }
                 }
             }
-            
+
             Console.WriteLine("Diff command: {0} {1}", asmTool, String.Join(" ", commandArgs));
-            
+
             Command diffCmd = Command.Create(
-                        asmTool, 
+                        asmTool,
                         commandArgs);
-                        
+
             // Wireup stdout/stderr so we can see outout.
             diffCmd.ForwardStdOut();
             diffCmd.ForwardStdErr();
-            
+
             CommandResult result = diffCmd.Execute();
-            
-            if (result.ExitCode != 0) {
+
+            if (result.ExitCode != 0)
+            {
                 Console.WriteLine("Returned with {0} failures", result.ExitCode);
             }
-            
+
             return result.ExitCode;
         }
     }

--- a/src/mcgdiff/mcgdiff.cs
+++ b/src/mcgdiff/mcgdiff.cs
@@ -45,9 +45,9 @@ namespace ManagedCodeGen
         private IReadOnlyList<string> platformPaths = Array.Empty<string>();
         private bool dumpGCInfo = false;
         private bool verbose = false;
-        
-        public Config(string[] args) {
 
+        public Config(string[] args)
+        {
             syntaxResult = ArgumentSyntax.Parse(args, syntax =>
             {
                 syntax.DefineOption("b|base", ref baseExe, "The base compiler exe.");
@@ -59,23 +59,23 @@ namespace ManagedCodeGen
                 syntax.DefineOption("v|verbose", ref verbose, "Enable verbose output.");
                 var waitArg = syntax.DefineOption("w|wait", ref wait, "Wait for debugger to attach.");
                 waitArg.IsHidden = true;
-                
+
                 syntax.DefineOption("r|recursive", ref recursive, "Scan directories recursively.");
                 syntax.DefineOptionList("p|platform", ref platformPaths, "Path to platform assemblies");
-                var methodsArg = syntax.DefineOptionList("m|methods", ref methods, 
+                var methodsArg = syntax.DefineOptionList("m|methods", ref methods,
                     "List of methods to disasm.");
                 methodsArg.IsHidden = true;
-                
+
                 // Warning!! - Parameters must occur after options to preserve parsing semantics.
 
                 syntax.DefineParameterList("assembly", ref assemblyList, "The list of assemblies or directories to scan for assemblies.");
             });
-            
+
             // Run validation code on parsed input to ensure we have a sensible scenario.
-            
+
             validate();
         }
-        
+
         // Validate supported scenarios
         // 
         //    Scenario 1:  --base and --diff
@@ -86,76 +86,90 @@ namespace ManagedCodeGen
         //       Pass single tool as either --base or --diff and tag the result directory with a user
         //       supplied tag.
         //
-        private void validate() {
-            
-            if ((baseExe == null) && (diffExe == null)) {
+        private void validate()
+        {
+            if ((baseExe == null) && (diffExe == null))
+            {
                 syntaxResult.ReportError("Specify --base and/or --diff.");
             }
-            
-            if ((tag != null) && (diffExe != null)  && (baseExe != null)) {
+
+            if ((tag != null) && (diffExe != null) && (baseExe != null))
+            {
                 syntaxResult.ReportError("Multiple compilers with the same tag: Specify --diff OR --base seperatly with --tag (one compiler for one tag).");
             }
-            
-            if ((fileName == null) && (assemblyList.Count == 0)) {
+
+            if ((fileName == null) && (assemblyList.Count == 0))
+            {
                 syntaxResult.ReportError("No input: Specify --file <arg> or list input assemblies.");
             }
-            
+
             // Check that we can find the baseExe.
-            if (baseExe != null) {
-                if (!File.Exists(baseExe)) {
-                    syntaxResult.ReportError("Can't find --base tool.");   
-                } else {
+            if (baseExe != null)
+            {
+                if (!File.Exists(baseExe))
+                {
+                    syntaxResult.ReportError("Can't find --base tool.");
+                }
+                else
+                {
                     // Set to full path for the command resolution logic.
                     string fullBasePath = Path.GetFullPath(baseExe);
                     baseExe = fullBasePath;
                 }
             }
-            
+
             // Check that we can find the diffExe.
-            if (diffExe != null) {
-                if (!File.Exists(diffExe)) {
+            if (diffExe != null)
+            {
+                if (!File.Exists(diffExe))
+                {
                     syntaxResult.ReportError("Can't find --diff tool.");
-                } else {
+                }
+                else
+                {
                     // Set to full path for command resolution logic.
                     string fullDiffPath = Path.GetFullPath(diffExe);
                     diffExe = fullDiffPath;
                 }
             }
-            
-            if (fileName != null) {
-                if (!File.Exists(fileName)) {
+
+            if (fileName != null)
+            {
+                if (!File.Exists(fileName))
+                {
                     var message = String.Format("Error reading input file {0}, file not found.", fileName);
                     syntaxResult.ReportError(message);
                 }
             }
         }
-        
-        public bool HasUserAssemblies { get { return AssemblyList.Count > 0; }}
-        public bool DoFileOutput { get {return (this.RootPath != null);}}
-        public bool WaitForDebugger { get { return wait; }}
-        public bool GenerateBaseline { get { return (baseExe != null); }}
-        public bool GenerateDiff { get { return (diffExe != null); }}
-        public bool HasTag { get { return (tag != null); }}
-        public bool Recursive { get { return recursive; }}
-        public bool UseFileName { get { return (fileName != null); }}
-        public bool DumpGCInfo { get { return dumpGCInfo; }}
-        public bool DoVerboseOutput { get { return verbose; }}
-        public string BaseExecutable { get { return baseExe; }}
-        public string DiffExecutable { get { return diffExe; }}
-        public string RootPath { get { return rootPath; }}
-        public IReadOnlyList<string> PlatformPaths { get {return platformPaths; }}
-        public string Tag { get { return tag; }}
-        public string FileName { get { return fileName; }}
-        public IReadOnlyList<string> AssemblyList { get { return assemblyList; }}
+
+        public bool HasUserAssemblies { get { return AssemblyList.Count > 0; } }
+        public bool DoFileOutput { get { return (this.RootPath != null); } }
+        public bool WaitForDebugger { get { return wait; } }
+        public bool GenerateBaseline { get { return (baseExe != null); } }
+        public bool GenerateDiff { get { return (diffExe != null); } }
+        public bool HasTag { get { return (tag != null); } }
+        public bool Recursive { get { return recursive; } }
+        public bool UseFileName { get { return (fileName != null); } }
+        public bool DumpGCInfo { get { return dumpGCInfo; } }
+        public bool DoVerboseOutput { get { return verbose; } }
+        public string BaseExecutable { get { return baseExe; } }
+        public string DiffExecutable { get { return diffExe; } }
+        public string RootPath { get { return rootPath; } }
+        public IReadOnlyList<string> PlatformPaths { get { return platformPaths; } }
+        public string Tag { get { return tag; } }
+        public string FileName { get { return fileName; } }
+        public IReadOnlyList<string> AssemblyList { get { return assemblyList; } }
     }
 
-    public class AssemblyInfo {
-        public string Name {get; set;}
+    public class AssemblyInfo
+    {
+        public string Name { get; set; }
         // Contains path to assembly.
-        public string Path {get; set;}
+        public string Path { get; set; }
         // Contains relative path within output directory for given assembly.
         // This allows for different output directories per tool.
-        public string OutputPath {get; set;}
+        public string OutputPath { get; set; }
     }
 
     public class mcgdiff
@@ -165,57 +179,66 @@ namespace ManagedCodeGen
             // Error count will be returned.  Start at 0 - this will be incremented
             // based on the error counts derived from the DisasmEngine executions.
             int errorCount = 0;
-            
+
             // Parse and store comand line options.
             var config = new Config(args);
 
             // Stop to attach a debugger if desired.
-            if (config.WaitForDebugger) {
+            if (config.WaitForDebugger)
+            {
                 WaitForDebugger();
             }
 
             // Builds assemblyInfoList on mcgdiff
             List<AssemblyInfo> assemblyWorkList = GenerateAssemblyWorklist(config);
-            
+
             // The disasm engine encapsulates a particular set of diffs.  An engine is
             // produced with a given code generator and assembly list, which then produces
             // a set of disasm outputs
-            
-            if (config.GenerateBaseline) {
+
+            if (config.GenerateBaseline)
+            {
                 string taggedPath = null;
-                if (config.DoFileOutput) {
+                if (config.DoFileOutput)
+                {
                     string tag = "base";
-                    if (config.HasTag) {
+                    if (config.HasTag)
+                    {
                         tag = config.Tag;
                     }
-                    
+
                     taggedPath = Path.Combine(config.RootPath, tag);
                 }
-                
+
                 DisasmEngine baseDisasm = new DisasmEngine(config.BaseExecutable, config, taggedPath, assemblyWorkList);
                 baseDisasm.GenerateAsm();
 
-                if (baseDisasm.ErrorCount > 0) {
+                if (baseDisasm.ErrorCount > 0)
+                {
                     Console.WriteLine("{0} errors compiling base set.", baseDisasm.ErrorCount);
                     errorCount += baseDisasm.ErrorCount;
                 }
             }
-            
-            if (config.GenerateDiff) {
+
+            if (config.GenerateDiff)
+            {
                 string taggedPath = null;
-                if (config.DoFileOutput) {
+                if (config.DoFileOutput)
+                {
                     string tag = "diff";
-                    if (config.HasTag) {
+                    if (config.HasTag)
+                    {
                         tag = config.Tag;
                     }
-                    
+
                     taggedPath = Path.Combine(config.RootPath, tag);
                 }
-    
+
                 DisasmEngine diffDisasm = new DisasmEngine(config.DiffExecutable, config, taggedPath, assemblyWorkList);
                 diffDisasm.GenerateAsm();
-                
-                if (diffDisasm.ErrorCount > 0) {
+
+                if (diffDisasm.ErrorCount > 0)
+                {
                     Console.WriteLine("{0} errors compiling diff set.", diffDisasm.ErrorCount);
                     errorCount += diffDisasm.ErrorCount;
                 }
@@ -224,42 +247,47 @@ namespace ManagedCodeGen
             return errorCount;
         }
 
-        private static void WaitForDebugger() {
+        private static void WaitForDebugger()
+        {
             Console.WriteLine("Wait for a debugger to attach. Press ENTER to continue");
             Console.WriteLine($"Process ID: {Process.GetCurrentProcess().Id}");
             Console.ReadLine();
         }
-       
+
         public static List<AssemblyInfo> GenerateAssemblyWorklist(Config config)
         {
             bool verbose = config.DoVerboseOutput;
-            List<string> assemblyList = new List<string>(); 
+            List<string> assemblyList = new List<string>();
             List<AssemblyInfo> assemblyInfoList = new List<AssemblyInfo>();
 
             if (config.UseFileName)
             {
                 assemblyList = new List<string>();
                 string inputFile = config.FileName;
-                
+
                 // Open file, read assemblies one per line, and add them to the assembly list.
-                using (var inputStream = System.IO.File.Open(inputFile, FileMode.Open)) {
-                    using (var inputStreamReader = new StreamReader(inputStream)) {
+                using (var inputStream = System.IO.File.Open(inputFile, FileMode.Open))
+                {
+                    using (var inputStreamReader = new StreamReader(inputStream))
+                    {
                         string line;
-                        while ((line = inputStreamReader.ReadLine()) != null) {
+                        while ((line = inputStreamReader.ReadLine()) != null)
+                        {
                             // Each line is a path to an assembly.
                             if (!File.Exists(line))
                             {
                                 Console.WriteLine("Can't find {0} skipping...", line);
                                 continue;
                             }
-                            
+
                             assemblyList.Add(line);
                         }
                     }
                 }
             }
 
-            if (config.HasUserAssemblies) {
+            if (config.HasUserAssemblies)
+            {
                 // Append command line assemblies
                 assemblyList.AddRange(config.AssemblyList);
             }
@@ -267,48 +295,58 @@ namespace ManagedCodeGen
             // Process worklist and produce the info needed for the disasm engines.
             foreach (var path in assemblyList)
             {
-                // Handle directory case.
-                if (Directory.Exists(path)) {
-                    
+                FileAttributes attr;
+
+                if (File.Exists(path))
+                {
+                    attr = File.GetAttributes(path);
+                }
+                else
+                {
+                    Console.WriteLine("Can't find assembly {0}", path);
+                    continue;
+                }
+
+                if ((attr & FileAttributes.Directory) == FileAttributes.Directory)
+                {
                     if (verbose)
                     {
-                        Console.WriteLine("Processing directory: {0}", path);   
+                        Console.WriteLine("Processing directory: {0}", path);
                     }
-                     
+
                     // For the directory case create a stack and recursively find any
                     // assemblies for compilation.
                     List<AssemblyInfo> directoryAssemblyInfoList = IdentifyAssemblies(path,
                         config);
-                        
+
                     // Add info generated at this directory
                     assemblyInfoList.AddRange(directoryAssemblyInfoList);
                 }
-                else if (File.Exists(path)) {
+                else
+                {
                     // This is the file case.
 
-                    AssemblyInfo info = new AssemblyInfo {
+                    AssemblyInfo info = new AssemblyInfo
+                    {
                         Name = Path.GetFileName(path),
                         Path = Path.GetDirectoryName(path),
                         OutputPath = ""
                     };
-                            
+
                     assemblyInfoList.Add(info);
                 }
-                else {
-                    Console.WriteLine("Can't find {0}", path);
-                    continue;
-                }
             }
-                            
+
             return assemblyInfoList;
         }
-        
+
         // Check to see if the passed filePath is to an assembly.
-        private static bool IsAssembly(string filePath) {
+        private static bool IsAssembly(string filePath)
+        {
             try
             {
-                System.Reflection.AssemblyName diffAssembly = 
-                    System.Runtime.Loader.AssemblyLoadContext.GetAssemblyName(filePath);   
+                System.Reflection.AssemblyName diffAssembly =
+                    System.Runtime.Loader.AssemblyLoadContext.GetAssemblyName(filePath);
             }
             catch (System.IO.FileNotFoundException)
             {
@@ -327,15 +365,16 @@ namespace ManagedCodeGen
                 // (leave true in so as not to rely on fallthrough)
                 return true;
             }
-            
+
             return true;
         }
-        
+
         // Recursivly search for assemblies from a root path.
-        private static List<AssemblyInfo> IdentifyAssemblies(string rootPath, Config config) {
+        private static List<AssemblyInfo> IdentifyAssemblies(string rootPath, Config config)
+        {
             List<AssemblyInfo> assemblyInfoList = new List<AssemblyInfo>();
             string fullRootPath = Path.GetFullPath(rootPath);
-            SearchOption searchOption = (config.Recursive) ? 
+            SearchOption searchOption = (config.Recursive) ?
                 SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
 
             // Get files that could be assemblies, but discard currently
@@ -343,15 +382,17 @@ namespace ManagedCodeGen
             var subFiles = Directory.EnumerateFiles(rootPath, "*", searchOption)
                 .Where(s => (s.EndsWith(".exe") || s.EndsWith(".dll"))
                     && !s.Contains(".ni."));
-            
+
             foreach (var filePath in subFiles)
             {
-                if (config.DoVerboseOutput) {
-                    Console.WriteLine("Scaning: {0}", filePath);    
+                if (config.DoVerboseOutput)
+                {
+                    Console.WriteLine("Scaning: {0}", filePath);
                 }
-                
+
                 // skip if not an assembly
-                if (!IsAssembly(filePath)) {
+                if (!IsAssembly(filePath))
+                {
                     continue;
                 }
 
@@ -360,20 +401,21 @@ namespace ManagedCodeGen
                 string fullDirectoryName = Path.GetFullPath(directoryName);
                 string outputPath = fullDirectoryName.Substring(fullRootPath.Length).TrimStart(Path.DirectorySeparatorChar);
 
-                AssemblyInfo info = new AssemblyInfo {
+                AssemblyInfo info = new AssemblyInfo
+                {
                     Name = fileName,
                     Path = directoryName,
                     OutputPath = outputPath
                 };
-                
+
                 assemblyInfoList.Add(info);
             }
 
             return assemblyInfoList;
-        }       
+        }
 
-        class DisasmEngine
-        {   
+        private class DisasmEngine
+        {
             private string executablePath;
             private Config config;
             private string rootPath = null;
@@ -382,18 +424,18 @@ namespace ManagedCodeGen
             public bool doGCDump = false;
             public bool verbose = false;
             private int errorCount = 0;
-            
-            public int ErrorCount { get { return errorCount; }}
 
-            public DisasmEngine(string executable, Config config, string outputPath, 
+            public int ErrorCount { get { return errorCount; } }
+
+            public DisasmEngine(string executable, Config config, string outputPath,
                 List<AssemblyInfo> assemblyInfoList)
             {
                 this.config = config;
-                this.executablePath = executable;
-                this.rootPath = outputPath;
-                this.platformPaths = config.PlatformPaths;
+                executablePath = executable;
+                rootPath = outputPath;
+                platformPaths = config.PlatformPaths;
                 this.assemblyInfoList = assemblyInfoList;
-                
+
                 this.doGCDump = config.DumpGCInfo;
                 this.verbose = config.DoVerboseOutput;
             }
@@ -401,26 +443,28 @@ namespace ManagedCodeGen
             public void GenerateAsm()
             {
                 // Build a command per assembly to generate the asm output.
-                foreach (var assembly in this.assemblyInfoList)
+                foreach (var assembly in assemblyInfoList)
                 {
                     string fullPathAssembly = Path.Combine(assembly.Path, assembly.Name);
-                    
-                    if (!File.Exists(fullPathAssembly)) {
+
+                    if (!File.Exists(fullPathAssembly))
+                    {
                         // Assembly not found.  Produce a warning and skip this input.
                         Console.WriteLine("Skipping. Assembly not found: {0}", fullPathAssembly);
                         continue;
                     }
-                    
-                    List<string> commandArgs = new List<string>() {fullPathAssembly};
-                    
+
+                    List<string> commandArgs = new List<string>() { fullPathAssembly };
+
                     // Set platform assermbly path if it's defined.
-                    if (platformPaths.Count > 0) {
+                    if (platformPaths.Count > 0)
+                    {
                         commandArgs.Insert(0, "/Platform_Assemblies_Paths");
                         commandArgs.Insert(1, String.Join(" ", platformPaths));
                     }
 
                     Command generateCmd = Command.Create(
-                        executablePath, 
+                        executablePath,
                         commandArgs);
 
                     // Set up environment do disasm.
@@ -428,18 +472,21 @@ namespace ManagedCodeGen
                     generateCmd.EnvironmentVariable("COMPlus_NgenUnwindDump", "*");
                     generateCmd.EnvironmentVariable("COMPlus_NgenEHDump", "*");
                     generateCmd.EnvironmentVariable("COMPlus_JitDiffableDasm", "1");
-                    
-                    if (this.doGCDump) {
+
+                    if (this.doGCDump)
+                    {
                         generateCmd.EnvironmentVariable("COMPlus_NgenGCDump", "*");
                     }
 
-                    if (this.verbose) {
+                    if (this.verbose)
+                    {
                         Console.WriteLine("Running: {0} {1}", executablePath, String.Join(" ", commandArgs));
                     }
 
                     CommandResult result;
 
-                    if (this.rootPath != null) {
+                    if (rootPath != null)
+                    {
                         // Generate path to the output file
                         var assemblyFileName = Path.ChangeExtension(assembly.Name, ".dasm");
                         var path = Path.Combine(rootPath, assembly.OutputPath, assemblyFileName);
@@ -447,9 +494,10 @@ namespace ManagedCodeGen
                         PathUtility.EnsureParentDirectory(path);
 
                         // Redirect stdout/stderr to disasm file and run command.
-                        using (var outputStream = System.IO.File.Create(path)) {
-                            using (var outputStreamWriter = new StreamWriter(outputStream)) {
-                                
+                        using (var outputStream = System.IO.File.Create(path))
+                        {
+                            using (var outputStreamWriter = new StreamWriter(outputStream))
+                            {
                                 // Forward output and error to file.
                                 generateCmd.ForwardStdOut(outputStreamWriter);
                                 generateCmd.ForwardStdErr(outputStreamWriter);
@@ -457,20 +505,21 @@ namespace ManagedCodeGen
                             }
                         }
                     }
-                    else {
-
+                    else
+                    {
                         // By default forward to output to stdout/stderr.
                         generateCmd.ForwardStdOut();
                         generateCmd.ForwardStdErr();
                         result = generateCmd.Execute();
                     }
-                    
-                    if (result.ExitCode != 0) {
+
+                    if (result.ExitCode != 0)
+                    {
                         Console.WriteLine("Error running {0} on {1}", executablePath, fullPathAssembly);
                         errorCount++;
                     }
                 }
-            }   
+            }
         }
     }
 }


### PR DESCRIPTION
Ran CodeFormatter over the sources (minus local field name changes: CodeFormatter.exe /rule-:FieldNames)
Expecation is that new additions will use this when adding code.
